### PR TITLE
Kafka setup - Kraft controllers

### DIFF
--- a/config/broker1/server.properties
+++ b/config/broker1/server.properties
@@ -1,6 +1,6 @@
 process.roles=broker
 node.id=2
-controller.quorum.voters=1@kafka-controller:9093
+controller.quorum.voters=1@kafka-controller:9093,5@kafka-controller-2:9095,6@kafka-controller-3:9097
 listeners=PLAINTEXT://:9092
 log.dirs=/tmp/kraft-node-logs
 controller.listener.names=CONTROLLER

--- a/config/broker2/server.properties
+++ b/config/broker2/server.properties
@@ -1,6 +1,6 @@
 process.roles=broker
 node.id=3
-controller.quorum.voters=1@kafka-controller:9093
+controller.quorum.voters=1@kafka-controller:9093,5@kafka-controller-2:9095,6@kafka-controller-3:9097
 listeners=PLAINTEXT://:9094
 log.dirs=/tmp/kraft-node-logs
 controller.listener.names=CONTROLLER

--- a/config/broker3/server.properties
+++ b/config/broker3/server.properties
@@ -1,6 +1,6 @@
 process.roles=broker
 node.id=4
-controller.quorum.voters=1@kafka-controller:9093
+controller.quorum.voters=1@kafka-controller:9093,5@kafka-controller-2:9095,6@kafka-controller-3:9097
 listeners=PLAINTEXT://:9096
 log.dirs=/tmp/kraft-node-logs
 controller.listener.names=CONTROLLER

--- a/config/controller2/server.properties
+++ b/config/controller2/server.properties
@@ -1,7 +1,7 @@
 process.roles=controller
-node.id=1
+node.id=5
 controller.quorum.voters=1@kafka-controller:9093,5@kafka-controller-2:9095,6@kafka-controller-3:9097
 controller.listener.names=CONTROLLER
-listeners=CONTROLLER://:9093
+listeners=CONTROLLER://:9095
 listener.security.protocol.map=CONTROLLER:PLAINTEXT
 log.dirs=/tmp/kraft-node-logs

--- a/config/controller3/server.properties
+++ b/config/controller3/server.properties
@@ -1,7 +1,7 @@
 process.roles=controller
-node.id=1
+node.id=6
 controller.quorum.voters=1@kafka-controller:9093,5@kafka-controller-2:9095,6@kafka-controller-3:9097
 controller.listener.names=CONTROLLER
-listeners=CONTROLLER://:9093
+listeners=CONTROLLER://:9097
 listener.security.protocol.map=CONTROLLER:PLAINTEXT
 log.dirs=/tmp/kraft-node-logs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,6 @@ services:
     image: apache/kafka:latest
     container_name: kafka-controller-format
     hostname: kafka-controller-format
-    user: "1000:1000"
     depends_on:
       - init-perms
     command: >
@@ -36,7 +35,6 @@ services:
     image: apache/kafka:latest
     container_name: kafka-broker1-format
     hostname: kafka-broker1-format
-    user: "1000:1000"
     depends_on:
       - init-perms
     command: >
@@ -51,7 +49,6 @@ services:
     image: apache/kafka:latest
     container_name: kafka-broker2-format
     hostname: kafka-broker2-format
-    user: "1000:1000"
     depends_on:
       - init-perms
     command: >
@@ -67,7 +64,6 @@ services:
     image: apache/kafka:latest
     container_name: kafka-broker3-format
     hostname: kafka-broker3-format
-    user: "1000:1000"
     depends_on:
       - init-perms
     command: >
@@ -98,8 +94,6 @@ services:
     container_name: kafka-broker1
     hostname: kafka-broker1
     entrypoint: /wait-for-meta.sh
-    environment:
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
     depends_on:
       - kafka-broker1-format
       - init-perms
@@ -119,8 +113,6 @@ services:
     container_name: kafka-broker2
     hostname: kafka-broker2
     entrypoint: /wait-for-meta.sh
-    environment:
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
     depends_on:
       - kafka-broker2-format
       - init-perms
@@ -140,8 +132,6 @@ services:
     container_name: kafka-broker3
     hostname: kafka-broker3
     entrypoint: /wait-for-meta.sh
-    environment:
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
     depends_on:
       - kafka-broker3-format
       - init-perms

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,12 +5,16 @@ services:
     command: >
       sh -c "
         chown -R 1000:1000 /controller_data &&
+        chown -R 1000:1000 /controller2_data &&
+        chown -R 1000:1000 /controller3_data &&
         chown -R 1000:1000 /broker1_data &&
         chown -R 1000:1000 /broker2_data &&
         chown -R 1000:1000 /broker3_data
       "
     volumes:
       - controller_data:/controller_data
+      - controller2_data:/controller2_data
+      - controller3_data:/controller3_data
       - broker1_data:/broker1_data
       - broker2_data:/broker2_data
       - broker3_data:/broker3_data
@@ -28,6 +32,34 @@ services:
     volumes:
       - ./config/controller:/etc/kafka/kraft
       - controller_data:/tmp/kraft-node-logs
+    networks:
+      - kafka-net
+
+  kafka-controller2-format:
+    image: apache/kafka:latest
+    container_name: kafka-controller2-format
+    hostname: kafka-controller2-format
+    depends_on:
+      - init-perms
+    command: >
+      sh -c "/opt/kafka/bin/kafka-storage.sh format --cluster-id kraft-cluster --config /etc/kafka/kraft/server.properties"
+    volumes:
+      - ./config/controller2:/etc/kafka/kraft
+      - controller2_data:/tmp/kraft-node-logs
+    networks:
+      - kafka-net
+
+  kafka-controller3-format:
+    image: apache/kafka:latest
+    container_name: kafka-controller3-format
+    hostname: kafka-controller3-format
+    depends_on:
+      - init-perms
+    command: >
+      sh -c "/opt/kafka/bin/kafka-storage.sh format --cluster-id kraft-cluster --config /etc/kafka/kraft/server.properties"
+    volumes:
+      - ./config/controller3:/etc/kafka/kraft
+      - controller3_data:/tmp/kraft-node-logs
     networks:
       - kafka-net
 
@@ -59,7 +91,6 @@ services:
     networks:
       - kafka-net
 
-
   kafka-broker3-format:
     image: apache/kafka:latest
     container_name: kafka-broker3-format
@@ -85,6 +116,36 @@ services:
     volumes:
       - ./config/controller:/etc/kafka/kraft
       - controller_data:/tmp/kraft-node-logs
+      - ./wait-for-meta.sh:/wait-for-meta.sh
+    networks:
+      - kafka-net
+
+  kafka-controller-2:
+    image: apache/kafka:latest
+    container_name: kafka-controller-2
+    hostname: kafka-controller-2
+    entrypoint: /wait-for-meta.sh
+    depends_on:
+      - kafka-controller-format
+      - init-perms
+    volumes:
+      - ./config/controller2:/etc/kafka/kraft
+      - controller2_data:/tmp/kraft-node-logs
+      - ./wait-for-meta.sh:/wait-for-meta.sh
+    networks:
+      - kafka-net
+
+  kafka-controller-3:
+    image: apache/kafka:latest
+    container_name: kafka-controller-3
+    hostname: kafka-controller-3
+    entrypoint: /wait-for-meta.sh
+    depends_on:
+      - kafka-controller-format
+      - init-perms
+    volumes:
+      - ./config/controller3:/etc/kafka/kraft
+      - controller3_data:/tmp/kraft-node-logs
       - ./wait-for-meta.sh:/wait-for-meta.sh
     networks:
       - kafka-net
@@ -148,6 +209,8 @@ services:
 
 volumes:
   controller_data:
+  controller2_data:
+  controller3_data:
   broker1_data:
   broker2_data:
   broker3_data:


### PR DESCRIPTION
## Added multi-controllers to kafka kraft configuration

- Leader Election and Failover: If the current controller leader fails, the quorum elects a new leader automatically, minimizing downtime.
- Consistent Metadata Replication: All controllers maintain a replicated metadata log using the Raft consensus algorithm. This ensures metadata consistency across failures.
- High Availability: With an odd number of controllers (typically 3 or 5), the cluster can tolerate the failure of up to ⌊n/2⌋ nodes without losing the ability to manage topics, partitions, and brokers.

added quorum voters for each node

## Cleaning of unused yaml properties

Removed ambiguous configuration (user selection for permissions & enviromment variables used in server.properties)